### PR TITLE
More fire.html updates from chris hayward

### DIFF
--- a/html/fire.html
+++ b/html/fire.html
@@ -148,7 +148,7 @@
         <div class="col-md-6">
           <div class="body-copy" style="padding: .5em;">
             <h4 style="text-decoration: underline;">High-z Suite</h4>
-            <p>This suite comprises 22 simulations from Ma et al. (2018), <a class="underline" target="_blank" rel="noopener" href="https://ui.adsabs.harvard.edu/abs/2019MNRAS.487.1844M/abstract">Ma et al. (2019)</a>,<a class="underline" target="_blank" rel="noopener" href="https://ui.adsabs.harvard.edu/abs/2020MNRAS.493.4315M/abstract">Ma et al. 2020</a> simulated to z = 5. For each simulation, we release 11 snapshots across z = 5 − 10.</p>
+            <p>This suite comprises 22 simulations from <a class="underline" target="_blank" rel="noopener" href="https://ui.adsabs.harvard.edu/abs/2018MNRAS.478.1694M/abstract">Ma et al. (2018)</a>, <a class="underline" target="_blank" rel="noopener" href="https://ui.adsabs.harvard.edu/abs/2019MNRAS.487.1844M/abstract">Ma et al. (2019)</a>, <a class="underline" target="_blank" rel="noopener" href="https://ui.adsabs.harvard.edu/abs/2020MNRAS.493.4315M/abstract">Ma et al. (2020)</a> simulated to z = 5. For each simulation, we release 11 snapshots across z = 5 − 10.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
From @cchayward:

```
Under "High-z Suite", could you please make "Ma et al. (2018)" a link to https://ui.adsabs.harvard.edu/abs/2018MNRAS.478.1694M/abstract?

Also, please insert the missing space after "(2019)," on that same line and put "2020" in parentheses.
```