### PR TITLE
Encode Long and ULong values as strings in json

### DIFF
--- a/src/Ingest/GaiaDR3.hs
+++ b/src/Ingest/GaiaDR3.hs
@@ -46,8 +46,8 @@ indexLevel :: Int
 indexLevel = 59 - 2*level where level = 8
 
 -- |convert from source_id to file naming, HEALpix index level 8
-keyIndex :: Key -> Int
-keyIndex = fromIntegral . (`shiftR` indexLevel)
+_keyIndex :: Key -> Int
+_keyIndex = fromIntegral . (`shiftR` indexLevel)
 
 indexKey :: Int -> Key
 indexKey = (`shiftL` indexLevel) . fromIntegral

--- a/src/Ingest/HDF5.hs
+++ b/src/Ingest/HDF5.hs
@@ -622,9 +622,8 @@ ingestEagle inginfo = do
       return (n, b)
     nsub <- case ingestJoin info of
       Just IngestHaloJoin
-        { joinIngest = subinfo@Ingest{ ingestCatalog = Catalog{ catalogFields = subcat }, ingestJoin = Just (IngestJoin supfs) }
+        { joinIngest = subinfo@Ingest{ ingestJoin = Just (IngestJoin supfs) }
         , joinFirst = (`lookup` fof) -> Just (Long fofid)
-        , joinCount = fofcountf
         , joinParent = subgf
         } -> liftBaseOp (withGroup hf (simn <> "_Subhalo")) $ \hs -> do
         let fofmap = IM.fromDistinctAscList $ zip (map fromIntegral $ VS.toList fofid) [0..]


### PR DESCRIPTION
This only affects the new api, not the old/current catalog interafce (which just munges json coming back from ES directly).